### PR TITLE
add variables object to graphql queries

### DIFF
--- a/frontend/src/pages/Auth.js
+++ b/frontend/src/pages/Auth.js
@@ -27,25 +27,33 @@ class AuthPage extends Component {
 
     let requestBody = {
       query: `
-        query {
-          login(email: "${email}", password: "${password}") {
+        query Login($email: String!, $password: String!) {
+          login(email: $email, password: $password) {
             userId
             token
             tokenExpiration
           }
         }
-      `
+      `,
+      variables: {
+        email,
+        password
+      }
     }
     if (!this.state.isLogin) {
       requestBody = {
         query: `
-          mutation {
-            createUser(userInput: {email: "${email}", password: "${password}"}) {
+          mutation CreateUser($email: String!, $password: String!) {
+            createUser(userInput: {email: $email, password: $password}) {
               _id
               email
             }
           }
-        `
+        `,
+        variables: {
+          email,
+          password
+        }
       }
     }
 

--- a/frontend/src/pages/Bookings.js
+++ b/frontend/src/pages/Bookings.js
@@ -26,13 +26,16 @@ class BookingsPage extends Component {
     const token = this.context.token
     const requestBody = {
       query: `
-        mutation {
-          cancelBooking(bookingId: "${booking._id}") {
+        mutation CancelBooking($id: ID!) {
+          cancelBooking(bookingId: $id) {
             _id
             title
           }
         }
-      `
+      `,
+      variables: {
+        id: booking._id
+      }
     }
 
     fetch('http://localhost:8000/graphql', {

--- a/frontend/src/pages/Events.js
+++ b/frontend/src/pages/Events.js
@@ -54,14 +54,17 @@ class EventsPage extends Component {
     const { selectedEvent } = this.state
     const requestBody = {
       query: `
-        mutation {
-          bookEvent(eventId: "${selectedEvent._id}") {
+        mutation BookEvent($id: ID!) {
+          bookEvent(eventId: $id) {
             _id
             createdAt
             updatedAt
           }
         }
-      `
+      `,
+      variables: {
+        id: selectedEvent._id
+      }
     }
 
     fetch('http://localhost:8000/graphql', {
@@ -97,8 +100,8 @@ class EventsPage extends Component {
 
     const requestBody = {
       query: `
-        mutation {
-          createEvent(eventInput: {title: "${title}", description: "${description}", price: ${price}, date: "${date}"}) {
+        mutation CreateEvent($title: String!, $description: String!, $price: String!, date: String!) {
+          createEvent(eventInput: {title: $title, description: $description, price: $price, date: $date}) {
             _id
             title
             description
@@ -106,7 +109,13 @@ class EventsPage extends Component {
             date
           }
         }
-      `
+      `,
+      variables: {
+        title,
+        description,
+        price,
+        date
+      }
     }
 
     const token = this.context.token


### PR DESCRIPTION
[Video](https://www.youtube.com/watch?v=DFSgyX9HXNA)

## Purpose
Small refactor to our graphql API calls, to use the recommended way

## Learning
We can send variables graphql calls as a separate object in the request body. For this use some random method name but pass variable names and types correctly. `$` sign needs to be used.